### PR TITLE
Update shard to support crystal 1.0

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -8,15 +8,19 @@ on:
 
 jobs:
   build:
-
+    strategy:
+      fail-fast: false
+      matrix:
+        crystal: [0.34.0, latest]
     runs-on: ubuntu-latest
-
-    container:
-      image: crystallang/crystal
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: shards install
-    - name: Run tests
-      run: crystal spec
+      - name: Download source
+        uses: actions/checkout@v2
+      - name: Install Crystal
+        uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+      - name: Install shards
+        run: shards update
+      - name: Run tests
+        run: crystal spec

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - Chris Watson <cawatson1993@gmail.com>
 
-crystal: 0.34.0
+crystal: ">= 0.34.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
👋 Hey there!

We use this library in https://github.com/luckyframework/avram_slugify so I was hoping this would be a good step in hopefully getting a release to support crystal 1.0 😄 

I updated the github actions workflow to use https://github.com/oprypin/install-crystal to test with the current version and v0.34.0 since it says that it supports that right now though the main thing is the shard.yml change.